### PR TITLE
Visa information URL accuracy

### DIFF
--- a/backend/agents/tools/search_tool.py
+++ b/backend/agents/tools/search_tool.py
@@ -14,7 +14,7 @@ def web_search(query: str, max_results: int = 5) -> str:
         max_results: Maximum number of results to return.
 
     Returns:
-        A string containing the search results (titles and snippets).
+        A string containing the search results (titles, URLs, snippets).
     """
     print(f"[SearchTool] Searching for: {query}")
     try:
@@ -28,7 +28,10 @@ def web_search(query: str, max_results: int = 5) -> str:
         for i, res in enumerate(results, 1):
             title = res.get('title', 'No Title')
             body = res.get('body', 'No Description')
-            formatted_results.append(f"{i}. {title}\n   {body}")
+            url = res.get('href') or res.get('url') or res.get('link') or 'No URL'
+            formatted_results.append(
+                f"{i}. {title}\n   URL: {url}\n   {body}"
+            )
 
         return "\n\n".join(formatted_results)
     except Exception as e:

--- a/backend/agents/visa_agent.py
+++ b/backend/agents/visa_agent.py
@@ -32,7 +32,7 @@ class VisaAgent(Agent):
 TASK: Provide accurate visa requirements for traveling from {origin} to {destination}.
 
 TOOL USAGE:
-- Make exactly 1 search call with query: "{origin} citizens visa requirements {destination} {current_date[:4]}"
+- Make exactly 1 search call with query: "{origin} citizens visa requirements {destination} official visa application site {current_date[:4]}"
 - DO NOT search more than once.
 
 AFTER SEARCHING, you MUST respond with ONLY a JSON object (no explanation, no markdown):
@@ -41,7 +41,7 @@ AFTER SEARCHING, you MUST respond with ONLY a JSON object (no explanation, no ma
   "required": true or false,
   "requirements": ["requirement 1", "requirement 2", ...],
   "processing_time": "X business days",
-  "application_url": "https://official-visa-site.com",
+  "application_url": "https://official-government-visa-site.gov",
   "application_steps": ["Step 1", "Step 2", ...]
 }}
 
@@ -49,6 +49,10 @@ IMPORTANT:
 - Output ONLY valid JSON, nothing else
 - No markdown code blocks, no explanations
 - Use real data from search results
+- The "application_url" MUST be copied from a search result URL
+- Prefer official government, immigration, embassy, or consulate domains
+- Never use generic sources (search engines, Wikipedia, travel blogs, visa brokers)
+- If no official URL is found, set "application_url" to null
 - If origin is unknown, assume tourist visa requirements""",
             tools=[web_search],
             output_schema=VisaInfo,


### PR DESCRIPTION
Enhance VisaAgent to fetch and provide accurate, official visa application URLs.

This PR addresses the issue of providing generic URLs by modifying the web search tool to return URLs and guiding the VisaAgent to specifically search for and extract application URLs from official government sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca524a3c-6dfe-4df9-aa91-0c3c6f5b5995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca524a3c-6dfe-4df9-aa91-0c3c6f5b5995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens visa URL accuracy by ensuring results include URLs and the agent sources links from official domains.
> 
> - Update `web_search` to include result URLs (tries `href`/`url`/`link`) and format outputs with title, URL, and snippet
> - Revise `VisaAgent` ADK instructions: search query now targets "official visa application site"; `application_url` must be copied from a search result, prefer government/embassy domains, avoid generic sources, and set to `null` if none found; example URL updated to a `.gov` domain
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cccefbf403623b390ac7964f67841c4b533ee34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->